### PR TITLE
Add install_matlab MCP tool for installing MATLAB via mpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Run MATLAB® using AI applications with the official MATLAB MCP Server from MathWorks®. The MATLAB MCP Core Server allows your AI applications to:
 
+- Install MATLAB and toolboxes without requiring a pre-existing MATLAB installation.
 - Start and quit MATLAB.
 - Write and run MATLAB code.
 - Assess your MATLAB code for style and correctness.
@@ -20,7 +21,7 @@ Run MATLAB® using AI applications with the official MATLAB MCP Server from Math
 
 ## Setup
 
-1. Install [MATLAB (MathWorks)](https://www.mathworks.com/help/install/ug/install-products-with-internet-connection.html) 2020b or later and add it to the system PATH.
+1. Install [MATLAB (MathWorks)](https://www.mathworks.com/help/install/ug/install-products-with-internet-connection.html) 2020b or later and add it to the system PATH. Alternatively, you can use the [`install_matlab`](#tools) tool to install MATLAB directly from your AI application after setting up the server.
 1. To set up the MATLAB MCP Core Server for Claude Desktop, skip to the instructions for [Claude Desktop](#claude-desktop). To set up the server for other applications, follow these instructions:
    
    - For Windows or Linux, [**Download the Latest Release**](https://github.com/matlab/matlab-mcp-core-server/releases/latest). (Alternatively, you can **build from source**: install [Go](https://go.dev/doc/install) and build the binary using `go install github.com/matlab/matlab-mcp-core-server/cmd/matlab-mcp-core-server@latest`).
@@ -109,8 +110,15 @@ Customize the behavior of the server by providing arguments in the `args` array 
 
 ## Tools
 
+1. `install_matlab`
+    - Downloads and installs MATLAB and/or MATLAB toolboxes using the MATLAB Package Manager (mpm). This tool does not require MATLAB to already be installed. It downloads the mpm CLI and uses it to install the specified products.
+    - Inputs:
+        - `release` (string): The MATLAB release to install (e.g., `R2025a` or `R2024b`).
+        - `products` (string[]): List of product names to install. Use underscores for spaces (e.g., `MATLAB`, `Signal_Processing_Toolbox`, `Deep_Learning_Toolbox`). To install MATLAB itself, include `MATLAB` in the list.
+        - `destination` (string, optional): The installation directory. If not specified, mpm uses its default location.
+
 1. `detect_matlab_toolboxes`
-    - Returns information about installed MATLAB and toolboxes, including version numbers.  
+    - Returns information about installed MATLAB and toolboxes, including version numbers.
 
 1. `check_matlab_code`
     - Performs static code analysis on a MATLAB script. Returns warnings about coding style, potential errors, deprecated functions, performance issues, and best practice violations. This is a non-destructive, read-only operation that helps identify code quality issues without executing the script.

--- a/internal/adaptors/mcp/server/configurator/configurator.go
+++ b/internal/adaptors/mcp/server/configurator/configurator.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/resources/codingguidelines"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/resources/plaintextlivecodegeneration"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools"
+	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/installmatlab"
 	evalmatlabcodemultisession "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/evalmatlabcode"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/listavailablematlabs"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/startmatlabsession"
@@ -46,6 +47,9 @@ type Configurator struct {
 	runMATLABFileInGlobalMATLABSessionTool         tools.Tool
 	runMATLABTestFileInGlobalMATLABSessionTool     tools.Tool
 
+	// Session-independent tools
+	installMATLABTool tools.Tool
+
 	// Resources
 	codingGuidelinesResource            resources.Resource
 	plaintextlivecodegenerationResource resources.Resource
@@ -67,6 +71,8 @@ func New(
 	runMATLABFileInGlobalMATLABSessionTool *runmatlabfile.Tool,
 	runMATLABTestFileInGlobalMATLABSessionTool *runmatlabtestfile.Tool,
 
+	installMATLABTool *installmatlab.Tool,
+
 	codingGuidelinesResource *codingguidelines.Resource,
 	plaintextlivecodegenerationResource *plaintextlivecodegeneration.Resource,
 ) *Configurator {
@@ -85,6 +91,8 @@ func New(
 		detectMATLABToolboxesInGlobalMATLABSessionTool: detectMATLABToolboxesInGlobalMATLABSessionTool,
 		runMATLABFileInGlobalMATLABSessionTool:         runMATLABFileInGlobalMATLABSessionTool,
 		runMATLABTestFileInGlobalMATLABSessionTool:     runMATLABTestFileInGlobalMATLABSessionTool,
+
+		installMATLABTool: installMATLABTool,
 
 		codingGuidelinesResource:            codingGuidelinesResource,
 		plaintextlivecodegenerationResource: plaintextlivecodegenerationResource,
@@ -108,6 +116,7 @@ func (c *Configurator) GetToolsToAdd() ([]tools.Tool, error) {
 			c.detectMATLABToolboxesInGlobalMATLABSessionTool,
 			c.runMATLABFileInGlobalMATLABSessionTool,
 			c.runMATLABTestFileInGlobalMATLABSessionTool,
+			c.installMATLABTool,
 		}, nil
 	}
 
@@ -116,6 +125,7 @@ func (c *Configurator) GetToolsToAdd() ([]tools.Tool, error) {
 		c.startMATLABSessionTool,
 		c.stopMATLABSessionTool,
 		c.evalInMATLABSessionTool,
+		c.installMATLABTool,
 	}, nil
 }
 

--- a/internal/adaptors/mcp/tools/installmatlab/definition.go
+++ b/internal/adaptors/mcp/tools/installmatlab/definition.go
@@ -1,0 +1,24 @@
+// Copyright 2026 The MathWorks, Inc.
+
+package installmatlab
+
+const (
+	name  = "install_matlab"
+	title = "Install MATLAB"
+	description = `Downloads and installs MATLAB and/or MATLAB toolboxes using the MATLAB Package Manager (mpm).
+This tool does NOT require MATLAB to already be installed. It downloads the mpm CLI and uses it to install the specified products.
+Product names use underscores for spaces (e.g., Signal_Processing_Toolbox, Deep_Learning_Toolbox).
+To install MATLAB itself, include "MATLAB" in the products list.`
+)
+
+// Args defines the input schema for the install_matlab tool.
+type Args struct {
+	Release     string   `json:"release"     jsonschema:"The MATLAB release to install (e.g. R2025a or R2024b)."`
+	Products    []string `json:"products"    jsonschema:"List of product names to install. Use underscores for spaces (e.g. MATLAB or Signal_Processing_Toolbox or Deep_Learning_Toolbox)."`
+	Destination string   `json:"destination,omitempty" jsonschema:"The installation directory. If not specified mpm uses its default location."`
+}
+
+// ReturnArgs defines the output schema for the install_matlab tool.
+type ReturnArgs struct {
+	Output string `json:"output" jsonschema:"The output from the mpm install command."`
+}

--- a/internal/adaptors/mcp/tools/installmatlab/tool.go
+++ b/internal/adaptors/mcp/tools/installmatlab/tool.go
@@ -1,0 +1,58 @@
+// Copyright 2026 The MathWorks, Inc.
+
+package installmatlab
+
+import (
+	"context"
+
+	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/annotations"
+	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/basetool"
+	"github.com/matlab/matlab-mcp-core-server/internal/entities"
+	"github.com/matlab/matlab-mcp-core-server/internal/usecases/installmatlab"
+)
+
+// Usecase defines the business logic interface for installing MATLAB products.
+type Usecase interface {
+	Execute(ctx context.Context, logger entities.Logger, args installmatlab.Args) (installmatlab.ReturnArgs, error)
+}
+
+// Tool is the MCP tool for installing MATLAB and toolboxes via mpm.
+type Tool struct {
+	basetool.ToolWithStructuredContentOutput[Args, ReturnArgs]
+}
+
+// New creates a new install_matlab tool.
+func New(
+	loggerFactory basetool.LoggerFactory,
+	usecase Usecase,
+) *Tool {
+	return &Tool{
+		ToolWithStructuredContentOutput: basetool.NewToolWithStructuredContent(
+			name, title, description,
+			annotations.NewDestructiveAnnotations(),
+			loggerFactory,
+			Handler(usecase),
+		),
+	}
+}
+
+// Handler returns the tool handler function.
+func Handler(usecase Usecase) basetool.HandlerWithStructuredContentOutput[Args, ReturnArgs] {
+	return func(ctx context.Context, sessionLogger entities.Logger, inputs Args) (ReturnArgs, error) {
+		sessionLogger.Info("Executing install MATLAB tool")
+		defer sessionLogger.Info("Done - Executing install MATLAB tool")
+
+		result, err := usecase.Execute(ctx, sessionLogger, installmatlab.Args{
+			Release:     inputs.Release,
+			Destination: inputs.Destination,
+			Products:    inputs.Products,
+		})
+		if err != nil {
+			return ReturnArgs{Output: result.Output}, err
+		}
+
+		return ReturnArgs{
+			Output: result.Output,
+		}, nil
+	}
+}

--- a/internal/adaptors/mpm/downloader.go
+++ b/internal/adaptors/mpm/downloader.go
@@ -1,0 +1,53 @@
+// Copyright 2026 The MathWorks, Inc.
+
+package mpm
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// Downloader downloads files from URLs to local paths.
+type Downloader struct{}
+
+func NewDownloader() *Downloader {
+	return &Downloader{}
+}
+
+// Download fetches the file at url and writes it to destPath.
+func (d *Downloader) Download(ctx context.Context, url string, destPath string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download from %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed with status %d from %s", resp.StatusCode, url)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for %s: %w", destPath, err)
+	}
+
+	out, err := os.Create(destPath) //nolint:gosec // destPath is constructed internally, not from user input
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", destPath, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return fmt.Errorf("failed to write to %s: %w", destPath, err)
+	}
+
+	return nil
+}

--- a/internal/adaptors/mpm/oslayer.go
+++ b/internal/adaptors/mpm/oslayer.go
@@ -1,0 +1,39 @@
+// Copyright 2026 The MathWorks, Inc.
+
+package mpm
+
+import (
+	"os"
+	"runtime"
+)
+
+// OSLayer provides OS-level operations for the install MATLAB usecase.
+type OSLayer struct{}
+
+func NewOSLayer() *OSLayer {
+	return &OSLayer{}
+}
+
+func (o *OSLayer) GOOS() string {
+	return runtime.GOOS
+}
+
+func (o *OSLayer) GOARCH() string {
+	return runtime.GOARCH
+}
+
+func (o *OSLayer) UserHomeDir() (string, error) {
+	return os.UserHomeDir()
+}
+
+func (o *OSLayer) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (o *OSLayer) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (o *OSLayer) Chmod(name string, mode os.FileMode) error {
+	return os.Chmod(name, mode)
+}

--- a/internal/adaptors/mpm/runner.go
+++ b/internal/adaptors/mpm/runner.go
@@ -1,0 +1,26 @@
+// Copyright 2026 The MathWorks, Inc.
+
+package mpm
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// Runner executes shell commands and returns their combined output.
+type Runner struct{}
+
+func NewRunner() *Runner {
+	return &Runner{}
+}
+
+// Run executes the named command with the given arguments and returns combined stdout/stderr.
+func (r *Runner) Run(ctx context.Context, name string, args []string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // name and args are constructed internally
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("command failed: %w", err)
+	}
+	return string(output), nil
+}

--- a/internal/usecases/installmatlab/installmatlab.go
+++ b/internal/usecases/installmatlab/installmatlab.go
@@ -1,0 +1,175 @@
+// Copyright 2026 The MathWorks, Inc.
+
+package installmatlab
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/matlab/matlab-mcp-core-server/internal/entities"
+)
+
+// FileDownloader downloads a file from a URL to a local path.
+type FileDownloader interface {
+	Download(ctx context.Context, url string, destPath string) error
+}
+
+// CommandRunner executes a command and returns its combined output.
+type CommandRunner interface {
+	Run(ctx context.Context, name string, args []string) (string, error)
+}
+
+// OSLayer provides OS-level operations needed by the usecase.
+type OSLayer interface {
+	GOOS() string
+	GOARCH() string
+	UserHomeDir() (string, error)
+	MkdirAll(path string, perm os.FileMode) error
+	Stat(name string) (os.FileInfo, error)
+	Chmod(name string, mode os.FileMode) error
+}
+
+type Args struct {
+	Release     string
+	Destination string
+	Products    []string
+}
+
+type ReturnArgs struct {
+	Output string
+}
+
+type Usecase struct {
+	downloader    FileDownloader
+	commandRunner CommandRunner
+	osLayer       OSLayer
+}
+
+func New(
+	downloader FileDownloader,
+	commandRunner CommandRunner,
+	osLayer OSLayer,
+) *Usecase {
+	return &Usecase{
+		downloader:    downloader,
+		commandRunner: commandRunner,
+		osLayer:       osLayer,
+	}
+}
+
+func (u *Usecase) Execute(ctx context.Context, logger entities.Logger, args Args) (ReturnArgs, error) {
+	logger.Debug("Entering InstallMATLAB Usecase")
+	defer logger.Debug("Exiting InstallMATLAB Usecase")
+
+	if args.Release == "" {
+		return ReturnArgs{}, fmt.Errorf("release is required (e.g., R2025a)")
+	}
+	if len(args.Products) == 0 {
+		return ReturnArgs{}, fmt.Errorf("at least one product name is required")
+	}
+
+	mpmPath, err := u.ensureMpm(ctx, logger)
+	if err != nil {
+		return ReturnArgs{}, fmt.Errorf("failed to ensure mpm is available: %w", err)
+	}
+
+	output, err := u.runMpmInstall(ctx, logger, mpmPath, args)
+	if err != nil {
+		return ReturnArgs{Output: output}, err
+	}
+
+	return ReturnArgs{Output: output}, nil
+}
+
+func (u *Usecase) ensureMpm(ctx context.Context, logger entities.Logger) (string, error) {
+	mpmPath, err := u.getMpmPath()
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := u.osLayer.Stat(mpmPath); err == nil {
+		logger.Info("mpm already present at " + mpmPath)
+		return mpmPath, nil
+	}
+
+	downloadURL, err := u.getMpmDownloadURL()
+	if err != nil {
+		return "", err
+	}
+
+	logger.With("url", downloadURL).Info("Downloading mpm")
+
+	if err := u.downloader.Download(ctx, downloadURL, mpmPath); err != nil {
+		return "", fmt.Errorf("failed to download mpm: %w", err)
+	}
+
+	if u.osLayer.GOOS() != "windows" {
+		if err := u.osLayer.Chmod(mpmPath, 0755); err != nil {
+			return "", fmt.Errorf("failed to make mpm executable: %w", err)
+		}
+	}
+
+	logger.Info("mpm downloaded to " + mpmPath)
+	return mpmPath, nil
+}
+
+func (u *Usecase) getMpmPath() (string, error) {
+	homeDir, err := u.osLayer.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+
+	mpmDir := filepath.Join(homeDir, ".mathworks", "mpm")
+	if err := u.osLayer.MkdirAll(mpmDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create mpm directory: %w", err)
+	}
+
+	binaryName := "mpm"
+	if u.osLayer.GOOS() == "windows" {
+		binaryName = "mpm.exe"
+	}
+
+	return filepath.Join(mpmDir, binaryName), nil
+}
+
+func (u *Usecase) getMpmDownloadURL() (string, error) {
+	goos := u.osLayer.GOOS()
+	goarch := u.osLayer.GOARCH()
+
+	switch {
+	case goos == "windows":
+		return "https://www.mathworks.com/mpm/win64/mpm", nil
+	case goos == "darwin" && goarch == "arm64":
+		return "https://www.mathworks.com/mpm/maca64/mpm", nil
+	case goos == "darwin" && goarch == "amd64":
+		return "https://www.mathworks.com/mpm/maci64/mpm", nil
+	case goos == "linux":
+		return "https://www.mathworks.com/mpm/glnxa64/mpm", nil
+	default:
+		return "", fmt.Errorf("unsupported platform: %s/%s", goos, goarch)
+	}
+}
+
+func (u *Usecase) runMpmInstall(ctx context.Context, logger entities.Logger, mpmPath string, args Args) (string, error) {
+	cmdArgs := []string{
+		"install",
+		"--release=" + args.Release,
+	}
+	if args.Destination != "" {
+		cmdArgs = append(cmdArgs, "--destination="+args.Destination)
+	}
+	cmdArgs = append(cmdArgs, "--products")
+	cmdArgs = append(cmdArgs, args.Products...)
+
+	logger.With("command", mpmPath+" "+strings.Join(cmdArgs, " ")).Info("Running mpm install")
+
+	output, err := u.commandRunner.Run(ctx, mpmPath, cmdArgs)
+	if err != nil {
+		return output, fmt.Errorf("mpm install failed: %w", err)
+	}
+
+	return output, nil
+}

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -45,6 +45,7 @@ import (
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/server/sdk"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/basetool"
+	installmatlabtool "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/installmatlab"
 	evalmatlabcodemultisessiontool "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/evalmatlabcode"
 	listavailablematlabstool "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/listavailablematlabs"
 	startmatlabsessiontool "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/startmatlabsession"
@@ -67,8 +68,10 @@ import (
 	"github.com/matlab/matlab-mcp-core-server/internal/facades/iofacade"
 	"github.com/matlab/matlab-mcp-core-server/internal/facades/osfacade"
 	"github.com/matlab/matlab-mcp-core-server/internal/facades/registryfacade"
+	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mpm"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/checkmatlabcode"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/detectmatlabtoolboxes"
+	"github.com/matlab/matlab-mcp-core-server/internal/usecases/installmatlab"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/evalmatlabcode"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/listavailablematlabs"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/runmatlabfile"
@@ -261,6 +264,19 @@ func Initialize(serverDefinition ApplicationDefinition) *Application {
 
 		runmatlabtestfile.New,
 		wire.Bind(new(runmatlabtestfile.PathValidator), new(*pathvalidator.PathValidator)),
+
+		// Install MATLAB tool (session-independent)
+		installmatlabtool.New,
+		wire.Bind(new(installmatlabtool.Usecase), new(*installmatlab.Usecase)),
+
+		installmatlab.New,
+		wire.Bind(new(installmatlab.FileDownloader), new(*mpm.Downloader)),
+		wire.Bind(new(installmatlab.CommandRunner), new(*mpm.Runner)),
+		wire.Bind(new(installmatlab.OSLayer), new(*mpm.OSLayer)),
+
+		mpm.NewDownloader,
+		mpm.NewRunner,
+		mpm.NewOSLayer,
 
 		// Resources
 		wire.Bind(new(baseresource.LoggerFactory), new(*logger.Factory)),

--- a/internal/wire/wire_gen.go
+++ b/internal/wire/wire_gen.go
@@ -44,6 +44,7 @@ import (
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/server/rootstore"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/server/sdk"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools"
+	installmatlab2 "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/installmatlab"
 	evalmatlabcode2 "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/evalmatlabcode"
 	listavailablematlabs2 "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/listavailablematlabs"
 	startmatlabsession2 "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/multisession/startmatlabsession"
@@ -53,6 +54,7 @@ import (
 	evalmatlabcode3 "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/singlesession/evalmatlabcode"
 	runmatlabfile2 "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/singlesession/runmatlabfile"
 	runmatlabtestfile2 "github.com/matlab/matlab-mcp-core-server/internal/adaptors/mcp/tools/singlesession/runmatlabtestfile"
+	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/mpm"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/messagecatalog"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/os"
 	"github.com/matlab/matlab-mcp-core-server/internal/adaptors/telemetry"
@@ -69,6 +71,7 @@ import (
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/checkmatlabcode"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/detectmatlabtoolboxes"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/evalmatlabcode"
+	"github.com/matlab/matlab-mcp-core-server/internal/usecases/installmatlab"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/listavailablematlabs"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/runmatlabfile"
 	"github.com/matlab/matlab-mcp-core-server/internal/usecases/runmatlabtestfile"
@@ -152,9 +155,14 @@ func Initialize(serverDefinition ApplicationDefinition) *Application {
 	runmatlabfileTool := runmatlabfile2.New(loggerFactory, factory, runmatlabfileUsecase, globalMATLAB)
 	runmatlabtestfileUsecase := runmatlabtestfile.New(pathValidator)
 	runmatlabtestfileTool := runmatlabtestfile2.New(loggerFactory, runmatlabtestfileUsecase, globalMATLAB)
+	downloader := mpm.NewDownloader()
+	runner := mpm.NewRunner()
+	osLayer := mpm.NewOSLayer()
+	installmatlabUsecase := installmatlab.New(downloader, runner, osLayer)
+	installmatlabTool := installmatlab2.New(loggerFactory, installmatlabUsecase)
 	resource := codingguidelines.New(loggerFactory)
 	plaintextlivecodegenerationResource := plaintextlivecodegeneration.New(loggerFactory)
-	configuratorConfigurator := configurator.New(factory, serverDefinition, tool, startmatlabsessionTool, stopmatlabsessionTool, evalmatlabcodeTool, tool2, checkmatlabcodeTool, detectmatlabtoolboxesTool, runmatlabfileTool, runmatlabtestfileTool, resource, plaintextlivecodegenerationResource)
+	configuratorConfigurator := configurator.New(factory, serverDefinition, tool, startmatlabsessionTool, stopmatlabsessionTool, evalmatlabcodeTool, tool2, checkmatlabcodeTool, detectmatlabtoolboxesTool, runmatlabfileTool, runmatlabtestfileTool, installmatlabTool, resource, plaintextlivecodegenerationResource)
 	serverServer := server3.New(sdkFactory, loggerFactory, lifecycleSignaler, configuratorConfigurator)
 	orchestratorOrchestrator := orchestrator.New(messageCatalog, lifecycleSignaler, serverDefinition, factory, serverServer, watchdog3, loggerFactory, processManager, directoryFactory)
 	modeSelector := modeselector.New(factory, parserParser, telemetryFactory, watchdogWatchdog, orchestratorOrchestrator, osFacade, lifecycleSignaler, loggerFactory)


### PR DESCRIPTION
Adds a new session-independent tool that downloads the MATLAB Package Manager (mpm) CLI and uses it to install MATLAB and toolboxes without requiring MATLAB to be pre-installed. The tool is available in both single-session and multi-session modes.